### PR TITLE
RIUI-418 - View all SSCS cases

### DIFF
--- a/api/cases/case-list.js
+++ b/api/cases/case-list.js
@@ -13,7 +13,7 @@ function dataLookup(column, caseRow) {
     }
     if (typeof column.lookup === "string") {
         return jp.query(caseRow, column.lookup);
-    } else if (column.lookup.length) {
+    } else if (Array.isArray(column.lookup)) {
         return column.lookup.map(part => {
             if (part.startsWith('$')) {
                 return jp.query(caseRow, part);
@@ -21,6 +21,7 @@ function dataLookup(column, caseRow) {
             return part;
         }).join(' ');
     }
+    throw new Error('lookup is neither a string or an array.')
 }
 
 function rawCasesReducer(cases, columns) {
@@ -48,6 +49,7 @@ module.exports = (req, res, next) => {
     }).then(casesData => {
         const aggregatedData = {...sscsCaseListTemplate, results : rawCasesReducer(casesData, sscsCaseListTemplate.columns)};
         res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('content-type', 'application/json');
         res.status(200).send(JSON.stringify(aggregatedData));
     }).catch(e => console.log(e))
 };

--- a/api/cases/case-list.js
+++ b/api/cases/case-list.js
@@ -1,0 +1,53 @@
+const sscsCaseListTemplate = require('./sscsCaseList.template');
+const generateRequest = require('../lib/request');
+const config = require('../../config');
+const jp = require('jsonpath');
+
+function getCases(userId, options, caseType = 'Benefit', caseStateId = 'appealCreated', jurisdiction = 'SSCS') {
+    return generateRequest(`${config.services.ccd_data_api}/caseworkers/${userId}/jurisdictions/${jurisdiction}/case-types/${caseType}/cases?state=${caseStateId}&page=1`, options)
+}
+
+function dataLookup(column, caseRow) {
+    if (column.value) {
+        return column.value;
+    }
+    if (typeof column.lookup === "string") {
+        return jp.query(caseRow, column.lookup);
+    } else if (column.lookup.length) {
+        return column.lookup.map(part => {
+            if (part.startsWith('$')) {
+                return jp.query(caseRow, part);
+            }
+            return part;
+        }).join(' ');
+    }
+}
+
+function rawCasesReducer(cases, columns) {
+    return cases.map(caseRow => {
+        return {
+            case_id: caseRow.id,
+            case_fields : columns.reduce((row, column) => {
+                row[column.case_field_id] = dataLookup(column, caseRow['case_data']);
+                return row;
+            }, {})
+        };
+    });
+}
+
+//List of cases
+module.exports = (req, res, next) => {
+    const token = req.auth.token;
+    const userId = req.auth.userId;
+
+    getCases(userId, {
+        headers : {
+            'Authorization' : `Bearer ${token}`,
+            'ServiceAuthorization' : req.headers.ServiceAuthorization
+        }
+    }).then(casesData => {
+        const aggregatedData = {...sscsCaseListTemplate, results : rawCasesReducer(casesData, sscsCaseListTemplate.columns)};
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.status(200).send(JSON.stringify(aggregatedData));
+    }).catch(e => console.log(e))
+};

--- a/api/cases/case-list.spec.js
+++ b/api/cases/case-list.spec.js
@@ -42,7 +42,7 @@ describe('case-list spec', () => {
                 .then(response => {
                     expect(response.body.results.length).toBe(0);
                     expect(response.body.columns.length).toBe(2); // 3 minus case reference
-                    expect(response.body.columns[0]).toEqual(sscsCaseListTemplate.columns[0]);
+                    expect(response.body.columns).toEqual(sscsCaseListTemplate.columns);
                 });
         });
     });
@@ -71,7 +71,7 @@ describe('case-list spec', () => {
                 .then(response => {
                     expect(response.body.columns.length).toBe(2); // 3 minus case reference
                     expect(response.body.results.length).toBe(1);
-                    expect(response.body.columns[0]).toEqual(sscsCaseListTemplate.columns[0]);
+                    expect(response.body.columns).toEqual(sscsCaseListTemplate.columns);
                     expect(response.body.results[0]).toEqual({
                         case_id: caseData[0].id,
                         case_fields: {

--- a/api/cases/case-list.spec.js
+++ b/api/cases/case-list.spec.js
@@ -1,0 +1,85 @@
+const proxyquire = require('proxyquire');
+const supertest = require('supertest');
+const express = require('express');
+const router = express.Router();
+const config = require('../../config');
+const sscsCaseListTemplate = require('./sscsCaseList.template');
+
+describe('case-list spec', () => {
+    const caseData = [];
+
+    let httpRequest;
+    let route;
+    let app;
+    let request;
+
+    beforeEach(() => {
+        httpRequest = jasmine.createSpy();
+        httpRequest.and.callFake(() => Promise.resolve(caseData));
+
+        route = proxyquire('./case-list', {
+            '../lib/request': httpRequest
+        });
+        router.get('/', route);
+        app = express();
+        app.use((req, res, next) => {
+            req.auth = {
+                token: '1234567',
+                userId: '1'
+            };
+            next();
+        });
+        app.use('/api/cases', router);
+
+        request = supertest(app);
+    });
+
+    describe('when no case data is returned', () => {
+
+        it('should return the columns with no rows', () => {
+            return request.get('/api/cases')
+                .expect(200)
+                .then(response => {
+                    expect(response.body.results.length).toBe(0);
+                    expect(response.body.columns.length).toBe(2); // 3 minus case reference
+                    expect(response.body.columns[0]).toEqual(sscsCaseListTemplate.columns[0]);
+                });
+        });
+    });
+
+    describe('when one row of case data is returned', () => {
+
+        beforeEach(() => {
+            caseData.push({
+                id: '987654321',
+                case_data: {
+                    appeal: {
+                        appellant: {
+                            name: {
+                                firstName: 'Louis',
+                                lastName: 'Houghton'
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        it('should return the columns with one rows', () => {
+            return request.get('/api/cases')
+                .expect(200)
+                .then(response => {
+                    expect(response.body.columns.length).toBe(2); // 3 minus case reference
+                    expect(response.body.results.length).toBe(1);
+                    expect(response.body.columns[0]).toEqual(sscsCaseListTemplate.columns[0]);
+                    expect(response.body.results[0]).toEqual({
+                        case_id: caseData[0].id,
+                        case_fields: {
+                            parties: 'Louis Houghton versus DWP',
+                            type: 'PIP'
+                        }
+                    });
+                });
+        });
+    });
+});

--- a/api/cases/index.js
+++ b/api/cases/index.js
@@ -1,34 +1,14 @@
-const request = require('request-promise');
 const jp = require('jsonpath');
 const express = require('express');
 const router = express.Router();
 const config = require('../../config');
-const proxy = require('../lib/proxy');
-const jwtDecode = require('jwt-decode');
-const schema = require('../benefit_schema.json');
 const sscsCaseTemplate = require('./sscsCase.template');
-const sscsCaseListTemplate = require('./sscsCaseList.template');
-
-function generateRequest(url, params) {
-    let options = {
-        url : url, headers : {
-            ...params.headers, 'Content-Type' : 'application/json'
-        }, json : true
-    };
-    if(config.useProxy) {
-        options = proxy(options);
-    }
-    return request(options);
-}
-
+const generateRequest = require('../lib/request');
+const caseList = require('./case-list');
 
 function getCase(caseId, userId, options, caseType = 'Benefit', jurisdiction = 'SSCS') {
     // 1528476356357908
     return generateRequest(`${config.services.ccd_data_api}/caseworkers/${userId}/jurisdictions/${jurisdiction}/case-types/${caseType}/cases/${caseId}`, options)
-}
-
-function getCases(userId, options, caseType = 'Benefit', caseStateId = 'appealCreated', jurisdiction = 'SSCS') {
-    return generateRequest(`${config.services.ccd_data_api}/caseworkers/${userId}/jurisdictions/${jurisdiction}/case-types/${caseType}/cases?state=${caseStateId}&page=1`, options)
 }
 
 function replaceSectionValues(section, caseData) {
@@ -46,24 +26,6 @@ function replaceSectionValues(section, caseData) {
     }
 }
 
-
-function rawCasesReducer(cases) {
-    return cases.reduce((acc, curr) => {
-        acc.push({
-            'case_id' : curr.id, 'case_fields' : {
-                'caseReference' : null,
-                'parties' : `${curr['case_data'].appeal.appellant.name.firstName} vs ${curr['case_data'].appeal.appellant.name.lastName}`,
-                'type' : curr.jurisdiction, 'status' : 'unknown',
-                'caseCreated' : curr.created_date,
-                'caseLastActioned' : curr.last_modified
-            }
-        });
-        
-        return acc;
-        
-    }, []);
-}
-
 function caseFileReducer(caseId, caseFile) {
     return caseFile.reduce((acc, curr) => {
         const fileName = curr.value.documentLink.document_filename;
@@ -72,7 +34,7 @@ function caseFileReducer(caseId, caseFile) {
         const isImage = ['gif', 'jpg', 'png'].includes(docType);
         const isPdf = 'pdf' === docType;
         const isUnsupported = !isImage && !isPdf;
-        
+
         acc.push({
             'id' : docStoreId,
             'href' : `/viewcase/${caseId}/casefile/${docStoreId}`,
@@ -81,9 +43,9 @@ function caseFileReducer(caseId, caseFile) {
             'isImage' : isImage,
             'isPdf' : isPdf, 'isUnsupported' : isUnsupported
         });
-        
+
         return acc;
-        
+
     }, []);
 }
 
@@ -92,7 +54,7 @@ router.get('/:case_id', (req, res, next) => {
     const token = req.auth.token;
     const userId = req.auth.userId;
     const caseId = req.params.case_id;
-    
+
     getCase(caseId, userId, {
         headers : {
             'Authorization' : `Bearer ${token}`,
@@ -101,7 +63,7 @@ router.get('/:case_id', (req, res, next) => {
     }).then(caseData => {
         const schema = JSON.parse(JSON.stringify(sscsCaseTemplate));
         schema.sections.forEach(section => replaceSectionValues(section, caseData));
-        
+
         const rawCaseFile = schema.sections.filter(section => section.id === 'casefile')
         const caseFile = caseFileReducer(caseId, rawCaseFile[0].sections[0].fields[0].value[0]);
 
@@ -114,22 +76,7 @@ router.get('/:case_id', (req, res, next) => {
 
 
 //List of cases
-router.get('/', (req, res, next) => {
-    const token = req.auth.token;
-    const userId = req.auth.userId;
-    
-    getCases(userId, {
-        headers : {
-            'Authorization' : `Bearer ${token}`,
-            'ServiceAuthorization' : req.headers.ServiceAuthorization
-        }
-    }).then(casesData => {
-        const aggregatedData = {...sscsCaseListTemplate, results : rawCasesReducer(casesData)};
-        
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.status(200).send(JSON.stringify(aggregatedData));
-    }).catch(e => console.log(e))
-});
+router.get('/', caseList);
 
 
 module.exports = router;

--- a/api/cases/sscsCaseList.template.js
+++ b/api/cases/sscsCaseList.template.js
@@ -1,80 +1,49 @@
 module.exports = {
-  "columns": [
-    {
-      "label": "Parties",
-      "order": 2,
-      "case_field_id": "parties",
-      "case_field_type": {
-        "id": "Text",
-        "type": "Text",
-        "min": null,
-        "max": null,
-        "regular_expression": null,
-        "fixed_list_items": [],
-        "complex_fields": [],
-        "collection_field_type": null
-      }
-    },
-    {
-      "label": "Type",
-      "order": 3,
-      "case_field_id": "type",
-      "case_field_type": {
-        "id": "Text",
-        "type": "Text",
-        "min": null,
-        "max": null,
-        "regular_expression": null,
-        "fixed_list_items": [],
-        "complex_fields": [],
-        "collection_field_type": null
-      }
-    },
-    {
-      "label": "Status",
-      "order": 4,
-      "case_field_id": "status",
-      "case_field_type": {
-        "id": "Text",
-        "type": "Text",
-        "min": null,
-        "max": null,
-        "regular_expression": null,
-        "fixed_list_items": [],
-        "complex_fields": [],
-        "collection_field_type": null
-      }
-    },
-    {
-      "label": "Date",
-      "order": 5,
-      "case_field_id": "caseCreated",
-      "case_field_type": {
-        "id": "Date",
-        "type": "Date",
-        "min": null,
-        "max": null,
-        "regular_expression": null,
-        "fixed_list_items": [],
-        "complex_fields": [],
-        "collection_field_type": null
-      }
-    },
-    {
-      "label": "Last Action",
-      "order": 7,
-      "case_field_id": "caseLastActioned",
-      "case_field_type": {
-        "id": "Date",
-        "type": "Date",
-        "min": null,
-        "max": null,
-        "regular_expression": null,
-        "fixed_list_items": [],
-        "complex_fields": [],
-        "collection_field_type": null
-      }
-    }
-  ],
-  "results": []
+    "columns": [
+        {
+            "label": "Parties",
+            "order": 2,
+            "case_field_id": "parties",
+            "lookup": ["$.appeal.appellant.name.firstName", "$.appeal.appellant.name.lastName", "versus DWP"]
+        },
+        {
+            "label": "Type",
+            "order": 3,
+            "case_field_id": "type",
+            "value": "PIP",
+
+        }
+        // ,
+        // {
+        //     "label": "Date",
+        //     "order": 5,
+        //     "case_field_id": "caseCreated",
+        //     "case_field_type": {
+        //         "id": "Date",
+        //         "type": "Date",
+        //         "min": null,
+        //         "max": null,
+        //         "regular_expression": null,
+        //         "fixed_list_items": [],
+        //         "complex_fields": [],
+        //         "collection_field_type": null
+        //     }
+        // },
+        // {
+        //     "label": "Last Action",
+        //     "order": 7,
+        //     "case_field_id": "caseLastActioned",
+        //     "case_field_type": {
+        //         "id": "Date",
+        //         "type": "Date",
+        //         "min": null,
+        //         "max": null,
+        //         "regular_expression": null,
+        //         "fixed_list_items": [],
+        //         "complex_fields": [],
+        //         "collection_field_type": null
+        //     }
+        // }
+    ],
+    "results": []
 };

--- a/api/lib/request.js
+++ b/api/lib/request.js
@@ -1,0 +1,15 @@
+const config = require('../../config');
+const proxy = require('./proxy');
+const request = require('request-promise');
+
+module.exports = function generateRequest(url, params) {
+    let options = {
+        url : url, headers : {
+            ...params.headers, 'Content-Type' : 'application/json'
+        }, json : true
+    };
+    if(config.useProxy) {
+        options = proxy(options);
+    }
+    return request(options);
+};

--- a/api/lib/request.js
+++ b/api/lib/request.js
@@ -5,7 +5,8 @@ const request = require('request-promise');
 module.exports = function generateRequest(url, params) {
     let options = {
         url : url, headers : {
-            ...params.headers, 'Content-Type' : 'application/json'
+            ...params.headers,
+            'Content-Type' : 'application/json'
         }, json : true
     };
     if(config.useProxy) {

--- a/src/app/case.service.ts
+++ b/src/app/case.service.ts
@@ -24,36 +24,6 @@ export class CaseService {
         });
     }
 
-    getFixedList(listItems) {
-        const obj = {};
-
-        listItems.forEach(listItem => {
-            obj[listItem.code] = listItem.label;
-        });
-
-        return obj;
-    }
-
-    transform(data) {
-        const enumColumns = {};
-
-        data.columns.forEach(column => {
-            if (column.case_field_type.fixed_list_items.length) {
-                enumColumns[column.case_field_id] = this.getFixedList(column.case_field_type.fixed_list_items);
-            }
-        });
-
-        if (Object.keys(enumColumns).length > 0) {
-            data.results.forEach(result => {
-                for (const fieldName in enumColumns) {
-                    result.case_fields[fieldName] = enumColumns[fieldName][result.case_fields[fieldName]];
-                }
-            });
-        }
-
-        return data;
-    }
-
     search(): Observable<Object> {
         const url = `${this.configService.config.api_base_url}/api/cases`;
         const key = makeStateKey(url);
@@ -63,7 +33,6 @@ export class CaseService {
         }
         return this.httpClient
             .get(url)
-            .map(data => this.transform(data))
             .map(data => {
                 this.state.set(key, data);
                 return data;

--- a/src/app/domain/search-result/search-result.component.html
+++ b/src/app/domain/search-result/search-result.component.html
@@ -1,4 +1,4 @@
-<div>
+<div data-selector="search-result">
     <span class="heading-small">Case list</span>
     <app-table [data]="data | async"></app-table>
 </div>

--- a/src/app/domain/search-result/search-result.component.spec.ts
+++ b/src/app/domain/search-result/search-result.component.spec.ts
@@ -1,25 +1,138 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { SearchResultComponent } from './search-result.component';
+import {SearchResultComponent} from './search-result.component';
+import {SharedModule} from '../../shared/shared.module';
+import {DomainModule} from '../domain.module';
+import {CaseService} from '../../case.service';
+import {Selector} from '../../../../test/selector-helper';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+import {ConfigService} from '../../config.service';
+import {BrowserTransferStateModule, StateKey} from '@angular/platform-browser';
+import {makeStateKey, TransferState} from '@angular/platform-browser';
 
-xdescribe('SearchResultComponent', () => {
-  let component: SearchResultComponent;
-  let fixture: ComponentFixture<SearchResultComponent>;
+const columns = [{
+    'label': 'Parties',
+    'order': 2,
+    'case_field_id': 'parties',
+    'lookup': ['$.appeal.appellant.name.firstName', '$.appeal.appellant.name.lastName', 'versus DWP']
+},
+{
+    'label': 'Type',
+    'order': 3,
+    'case_field_id': 'type',
+    'value': 'PIP',
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ SearchResultComponent ]
-    })
-    .compileComponents();
-  }));
+}];
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SearchResultComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+describe('SearchResultComponent', () => {
+    let component: SearchResultComponent;
+    let fixture: ComponentFixture<SearchResultComponent>;
+    let httpMock: HttpTestingController;
+    let nativeElement;
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [],
+            imports: [DomainModule, SharedModule, BrowserTransferStateModule, HttpClientTestingModule],
+            providers: [CaseService, ConfigService]
+        })
+            .compileComponents();
+    }));
+
+    describe('when there is no data in the transfer state', () => {
+        beforeEach(() => {
+            fixture = TestBed.createComponent(SearchResultComponent);
+            component = fixture.componentInstance;
+            nativeElement = fixture.nativeElement;
+            httpMock = TestBed.get(HttpTestingController);
+            fixture.detectChanges();
+        });
+
+        it('should create', () => {
+            expect(component).toBeTruthy();
+        });
+
+        describe('when no rows are returned', () => {
+            beforeEach(async(() => {
+                const req = httpMock.expectOne('http://localhost:3000/api/cases');
+
+                req.flush({
+                    columns: columns,
+                    results: []
+                });
+            }));
+
+            beforeEach(async(() => {
+                fixture.whenStable().then(() => {
+                    fixture.detectChanges();
+                });
+            }));
+
+            it('should have zero rows', () => {
+                expect(nativeElement.querySelectorAll(Selector.selector('search-result|table-row')).length).toBe(0);
+            });
+        });
+
+        describe('when some rows are returned', () => {
+            const results = [{
+                case_id: '987654321',
+                case_fields: {
+                    parties: 'Louis Houghton versus DWP',
+                    type: 'PIP'
+                }
+            }];
+
+            beforeEach(async(() => {
+                const req = httpMock.expectOne('http://localhost:3000/api/cases');
+
+                req.flush({
+                    columns,
+                    results
+                });
+            }));
+
+            beforeEach(async(() => {
+                fixture.whenStable().then(() => {
+                    fixture.detectChanges();
+                });
+            }));
+
+            it('should have some rows', () => {
+                expect(nativeElement.querySelectorAll(Selector.selector('search-result|table-row')).length).toBe(results.length);
+            });
+        });
+    });
+
+
+    describe('when there is some data in the transfer state', () => {
+        const results = [{
+            case_id: '987654321',
+            case_fields: {
+                parties: 'Louis Houghton versus DWP',
+                type: 'PIP'
+            }
+        }];
+        let state: TransferState;
+
+        beforeEach(() => {
+            state = TestBed.get(TransferState);
+            const key: StateKey<Object> = makeStateKey('http://localhost:3000/api/cases');
+            state.set(key, {
+                columns,
+                results
+            });
+        });
+
+        beforeEach(() => {
+            fixture = TestBed.createComponent(SearchResultComponent);
+            component = fixture.componentInstance;
+            nativeElement = fixture.nativeElement;
+            httpMock = TestBed.get(HttpTestingController);
+            fixture.detectChanges();
+        });
+
+        it('should have some rows without hitting backend', () => {
+            expect(nativeElement.querySelectorAll(Selector.selector('search-result|table-row')).length).toBe(results.length);
+        });
+    });
 });

--- a/src/app/domain/search-result/search-result.component.spec.ts
+++ b/src/app/domain/search-result/search-result.component.spec.ts
@@ -23,6 +23,7 @@ const columns = [{
     'value': 'PIP',
 
 }];
+const casesUrl = 'http://localhost:3000/api/cases';
 
 describe('SearchResultComponent', () => {
     let component: SearchResultComponent;
@@ -54,7 +55,7 @@ describe('SearchResultComponent', () => {
 
         describe('when no rows are returned', () => {
             beforeEach(async(() => {
-                const req = httpMock.expectOne('http://localhost:3000/api/cases');
+                const req = httpMock.expectOne(casesUrl);
 
                 req.flush({
                     columns: columns,
@@ -83,7 +84,7 @@ describe('SearchResultComponent', () => {
             }];
 
             beforeEach(async(() => {
-                const req = httpMock.expectOne('http://localhost:3000/api/cases');
+                const req = httpMock.expectOne(casesUrl);
 
                 req.flush({
                     columns,
@@ -116,7 +117,8 @@ describe('SearchResultComponent', () => {
 
         beforeEach(() => {
             state = TestBed.get(TransferState);
-            const key: StateKey<Object> = makeStateKey('http://localhost:3000/api/cases');
+
+            const key: StateKey<Object> = makeStateKey(casesUrl);
             state.set(key, {
                 columns,
                 results


### PR DESCRIPTION
* Cleaned up case list API code and added Jasmine tests.
* Made the code pull out case data based on a `lookup` field in the column definitions.
* Added tests to front end component
* Handle no results and error from server with messages.

**Still to do**

* Styling - I think I'm going to ditch material table in `table-component` and just create an HTML table because material table doesn't work with the gov uk table styling that the prototype uses. I'll push this as another PR.

