### PR TITLE
Use SSCS case reference on dashboard

### DIFF
--- a/api/cases/case-list.js
+++ b/api/cases/case-list.js
@@ -11,6 +11,7 @@ function rawCasesReducer(cases, columns) {
     return cases.map(caseRow => {
         return {
             case_id: caseRow.id,
+            case_reference: valueProcessor(sscsCaseListTemplate.case_number.label, caseRow),
             case_fields : columns.reduce((row, column) => {
                 row[column.case_field_id] = valueProcessor(column.value, caseRow);
                 return row;
@@ -36,6 +37,6 @@ module.exports = (req, res, next) => {
         res.status(200).send(JSON.stringify(aggregatedData));
     }).catch(response => {
         console.log(response.error || response);
-        res.status(response.error.status).send(response.error.message);
+        res.status(response.error.status || 500).send(response.error.message);
     });
 };

--- a/api/cases/case-list.spec.js
+++ b/api/cases/case-list.spec.js
@@ -53,6 +53,7 @@ describe('case-list spec', () => {
             caseData.push({
                 id: '987654321',
                 case_data: {
+                    caseReference: '123-123-123',
                     appeal: {
                         appellant: {
                             name: {
@@ -76,6 +77,7 @@ describe('case-list spec', () => {
                     expect(response.body.columns).toEqual(sscsCaseListTemplate.columns);
                     expect(response.body.results[0]).toEqual({
                         case_id: caseData[0].id,
+                        case_reference: caseData[0].case_data.caseReference,
                         case_fields: {
                             parties: 'Louis Houghton vs DWP',
                             type: 'PIP',

--- a/api/cases/sscsCaseList.template.js
+++ b/api/cases/sscsCaseList.template.js
@@ -1,32 +1,31 @@
 module.exports = {
+    "case_number": {
+        "label": "$.case_data.caseReference",
+        "value": '$.id'
+    },
     "columns": [
         {
             "label": "Parties",
-            "order": 2,
             "case_field_id": "parties",
             "value": ["$.case_data.appeal.appellant.name.firstName", "$.case_data.appeal.appellant.name.lastName", "vs DWP"]
         },
         {
             "label": "Type",
-            "order": 3,
             "case_field_id": "type",
             "value": "PIP",
 
         },
         {
             "label": "Case Start Date",
-            "order": 4,
             "case_field_id": "caseStartDate",
             "value": "$.created_date",
             "date_format": "d MMMM yyyy \'at\' h:mmaaaaa\'m\'"
         },
         {
             "label": "Date of Last Action",
-            "order": 5,
             "case_field_id": "dateOfLastAction",
             "value": "$.last_modified",
             "date_format": "d MMMM yyyy \'at\' h:mmaaaaa\'m\'"
         }
-    ],
-    "results": []
+    ]
 };

--- a/src/app/domain/components/search-result/search-result.component.spec.ts
+++ b/src/app/domain/components/search-result/search-result.component.spec.ts
@@ -120,6 +120,7 @@ describe('SearchResultComponent', () => {
         describe('when some rows are returned', () => {
             const results = [{
                 case_id: '987654321',
+                case_reference: '123-456-789',
                 case_fields: {
                     parties: 'Louis Houghton versus DWP',
                     type: 'PIP',
@@ -160,6 +161,7 @@ describe('SearchResultComponent', () => {
     describe('when there is some data in the transfer state', () => {
         const results = [{
             case_id: '987654321',
+            case_reference: '123-456-789',
             case_fields: {
                 parties: 'Louis Houghton versus DWP',
                 type: 'PIP',

--- a/src/app/shared/components/table/table.component.html
+++ b/src/app/shared/components/table/table.component.html
@@ -4,7 +4,7 @@
         <ng-container cdkColumnDef="case_id">
             <cdk-header-cell *cdkHeaderCellDef class="govuk-table__header">Case Number</cdk-header-cell>
             <cdk-cell class="govuk-table__cell" *cdkCellDef="let row;">
-                <a data-selector="case-reference-link" href="/viewcase/{{row.case_id}}/summary">{{row.case_id}}</a>
+                <a data-selector="case-reference-link" href="/viewcase/{{row.case_id}}/summary">{{row.case_reference}}</a>
             </cdk-cell>
         </ng-container>
         <ng-container *ngFor="let column of resultView.columns" cdkColumnDef="{{column.case_field_id}}">

--- a/src/app/shared/components/table/table.component.spec.ts
+++ b/src/app/shared/components/table/table.component.spec.ts
@@ -86,6 +86,7 @@ const columns = [
 
 const result1 = {
     'case_id': 1528476356357908,
+    'case_reference': '123-123-123',
     'case_fields': {
         'caseReference': null,
         'parties': 'A vs May_146863',
@@ -97,6 +98,7 @@ const result1 = {
 };
 const result2 = {
     'case_id': 1528476358303157,
+    'case_reference': '321-321-321',
     'case_fields': {
         'caseReference': null,
         'parties': 'B vs May_417228',


### PR DESCRIPTION
The dashboard case number should be configurable and for SSCS it will be the SSCS case reference rather than the CCD id. The link still needs to be the CCD ID though.