### PR TITLE
improved error handling and UI teaks for create a decision

### DIFF
--- a/api/cases/case-list.spec.js
+++ b/api/cases/case-list.spec.js
@@ -82,7 +82,7 @@ describe('case-list spec', () => {
                         case_id: caseData[0].id,
                         case_reference: caseData[0].case_data.caseReference,
                         case_fields: {
-                            parties: 'Louis Houghton vs DWP',
+                            parties: 'Louis Houghton v DWP',
                             type: 'PIP',
                             caseStartDate: createdDate.toISOString(),
                             dateOfLastAction: updatedDate.toISOString()
@@ -177,7 +177,7 @@ describe('case-list spec', () => {
                         case_id: caseData[0].id,
                         case_reference: caseData[0].case_data.caseReference,
                         case_fields: {
-                            parties: 'Louis Houghton vs DWP',
+                            parties: 'Louis Houghton v DWP',
                             type: 'PIP',
                             caseStartDate: createdDate1.toISOString(),
                             dateOfLastAction: updatedDate1.toISOString()
@@ -187,7 +187,7 @@ describe('case-list spec', () => {
                         case_id: caseData[2].id,
                         case_reference: caseData[2].case_data.caseReference,
                         case_fields: {
-                            parties: 'Roopa Ramisetty vs DWP',
+                            parties: 'Roopa Ramisetty v DWP',
                             type: 'PIP',
                             caseStartDate: createdDate3.toISOString(),
                             dateOfLastAction: updatedDate3.toISOString()
@@ -197,7 +197,7 @@ describe('case-list spec', () => {
                         case_id: caseData[1].id,
                         case_reference: caseData[1].case_data.caseReference,
                         case_fields: {
-                            parties: 'Padmaja Ramisetti vs DWP',
+                            parties: 'Padmaja Ramisetti v DWP',
                             type: 'PIP',
                             caseStartDate: createdDate2.toISOString(),
                             dateOfLastAction: updatedDate2.toISOString()

--- a/api/cases/case.spec.js
+++ b/api/cases/case.spec.js
@@ -208,7 +208,7 @@ describe('case spec', () => {
                 expect(caseDetails.fields).toEqual([
                     {
                         "label": "Parties",
-                        "value": `${caseData.case_data.appeal.appellant.name.firstName} ${caseData.case_data.appeal.appellant.name.lastName} vs DWP`
+                        "value": `${caseData.case_data.appeal.appellant.name.firstName} ${caseData.case_data.appeal.appellant.name.lastName} v DWP`
                     },
                     {
                         "label": "Case number",

--- a/api/cases/sscsCase.template.js
+++ b/api/cases/sscsCase.template.js
@@ -5,7 +5,7 @@ module.exports = {
                 value: '$.case_data.caseReference'
             },
             {
-                value: ["$.case_data.appeal.appellant.name.firstName", "$.case_data.appeal.appellant.name.lastName", "vs DWP"],
+                value: ["$.case_data.appeal.appellant.name.firstName", "$.case_data.appeal.appellant.name.lastName", "v DWP"],
             }
         ]
     },
@@ -25,7 +25,7 @@ module.exports = {
                             fields: [
                                 {
                                     label: 'Parties',
-                                    value: ["$.case_data.appeal.appellant.name.firstName", "$.case_data.appeal.appellant.name.lastName", "vs DWP"],
+                                    value: ["$.case_data.appeal.appellant.name.firstName", "$.case_data.appeal.appellant.name.lastName", "v DWP"],
                                 },
                                 {
                                     label: 'Case number',
@@ -155,11 +155,11 @@ module.exports = {
     ],
     decision: {
         id: 'decision',
-        name: 'Make Decision',
+        name: 'Make a decision',
         type: 'decision-page',
         options: [
-            { id: 'appeal-upheld', name: 'Appeal Upheld' },
-            { id: 'appeal-denied', name: 'Appeal Denied' }
+            { id: 'appeal-upheld', name: 'Appeal upheld' },
+            { id: 'appeal-denied', name: 'Appeal denied' }
         ]
     }
 };

--- a/api/cases/sscsCaseList.template.js
+++ b/api/cases/sscsCaseList.template.js
@@ -6,7 +6,7 @@ module.exports = {
         {
             "label": "Parties",
             "case_field_id": "parties",
-            "value": ["$.case_data.appeal.appellant.name.firstName", "$.case_data.appeal.appellant.name.lastName", "vs DWP"]
+            "value": ["$.case_data.appeal.appellant.name.firstName", "$.case_data.appeal.appellant.name.lastName", "v DWP"]
         },
         {
             "label": "Type",

--- a/src/app/domain/case-viewer/components/summary-panel/summary-panel.component.spec.ts
+++ b/src/app/domain/case-viewer/components/summary-panel/summary-panel.component.spec.ts
@@ -41,7 +41,7 @@ describe('SummaryPanelComponent', () => {
                         'fields': [
                             {
                                 'label': 'Parties',
-                                'value': 'A May_146863 vs DWP'
+                                'value': 'A May_146863 v DWP'
                             },
                             {
                                 'label': 'Case number',

--- a/src/app/domain/components/casebar-details/casebar-details.component.spec.ts
+++ b/src/app/domain/components/casebar-details/casebar-details.component.spec.ts
@@ -34,7 +34,7 @@ describe('CaseBarDetailsComponent', () => {
                             value: '1234'
                         },
                         {
-                            value: 'Alec DT vs DWP',
+                            value: 'Alec DT v DWP',
                         }
                     ]
                 }

--- a/src/app/domain/components/decisions/decision-confirmation/decision-confirmation.component.html
+++ b/src/app/domain/components/decisions/decision-confirmation/decision-confirmation.component.html
@@ -4,13 +4,12 @@
             <div class="govuk-grid-column-two-thirds">
                 <div class="govuk-panel govuk-panel--confirmation">
                     <h2 class="govuk-panel__title">Decision confirmed</h2>
-                    <div class="govuk-panel__body">{{ caseId || 'NEED TO ADD CASE ID'}}</div>
+                    <div class="govuk-panel__body">{{caseId}}</div>
                 </div>
-                <p>Something here?</p>
-                <h2 class="govuk-heading-m">What happens next</h2>
+                <h2 class="govuk-heading-m">What happens next?</h2>
                 <p>We've sent this decision to admin and the case has been removed from your dashboard.</p>
                 <p>You will need to enter your decision in GAPs</p>
-                <p><a routerLink="">Go to your dashboard</a></p>
+                <p><a routerLink="">Back to dashboard</a></p>
             </div>
         </div>
     </main>

--- a/src/app/domain/components/decisions/decision-confirmation/decision-confirmation.component.spec.ts
+++ b/src/app/domain/components/decisions/decision-confirmation/decision-confirmation.component.spec.ts
@@ -38,7 +38,7 @@ describe('DecisionConfirmationComponent', () => {
                                         details: {
                                             fields: [
                                                 { value: '123' },
-                                                { value: 'bob vs bob' }
+                                                { value: 'bob v bob' }
                                             ]
                                         }
                                     }

--- a/src/app/domain/components/decisions/decision-make/decision-make.component.html
+++ b/src/app/domain/components/decisions/decision-make/decision-make.component.html
@@ -16,7 +16,7 @@
 
                 <app-radio-buttons
                     [id]="'make-decision'"
-                    [title]="'Make decision'"
+                    [title]="'Make a decision'"
                     [options]="options"
                     [inputedId]="award"
                     [errorMessage]="'Select your decision'"

--- a/src/app/domain/components/decisions/decision-make/decision-make.component.spec.ts
+++ b/src/app/domain/components/decisions/decision-make/decision-make.component.spec.ts
@@ -38,7 +38,7 @@ describe('DecisionMakeComponent', () => {
                                         details: {
                                             fields: [
                                                 { value: '123' },
-                                                { value: 'bob vs bob' }
+                                                { value: 'bob v bob' }
                                             ]
                                         },
                                         decision: {

--- a/src/app/domain/components/hearings/hearing-confirmation/hearing-confirmation.component.spec.ts
+++ b/src/app/domain/components/hearings/hearing-confirmation/hearing-confirmation.component.spec.ts
@@ -38,7 +38,7 @@ describe('HearingConfirmationComponent', () => {
                                         details: {
                                             fields: [
                                                 { value: '123' },
-                                                { value: 'bob vs bob' }
+                                                { value: 'bob v bob' }
                                             ]
                                         }
                                     }

--- a/src/app/shared/components/table/table.component.spec.ts
+++ b/src/app/shared/components/table/table.component.spec.ts
@@ -90,7 +90,7 @@ const result1 = {
     'case_reference': '123-123-123',
     'case_fields': {
         'caseReference': null,
-        'parties': 'A vs May_146863',
+        'parties': 'A v May_146863',
         'type': 'SSCS',
         'status': 'unknown',
         'caseCreated': '2018-06-08T16:45:56.301',
@@ -102,7 +102,7 @@ const result2 = {
     'case_reference': '321-321-321',
     'case_fields': {
         'caseReference': null,
-        'parties': 'B vs May_417228',
+        'parties': 'B v May_417228',
         'type': 'SSCS',
         'status': 'unknown',
         'caseCreated': '2018-06-08T16:45:58.349',


### PR DESCRIPTION
- Default view when going to the page 1st time
![screenshot from 2018-07-18 11-29-05](https://user-images.githubusercontent.com/3073565/42876274-0efec31e-8a7e-11e8-80f1-664a80a2f197.png)

- when you try to submit but no data is entered
![screenshot from 2018-07-18 11-29-25](https://user-images.githubusercontent.com/3073565/42876272-0ee95146-8a7e-11e8-8423-7c9d396304c0.png)

- when you try to submit but only have a decision note entered 
![screenshot from 2018-07-18 11-29-42](https://user-images.githubusercontent.com/3073565/42876271-0ed57784-8a7e-11e8-8982-8bcf4826b22a.png)

- when you try to submit but only have a decision award entered  
![screenshot from 2018-07-18 11-29-55](https://user-images.githubusercontent.com/3073565/42876270-0ec12bd0-8a7e-11e8-8ef3-226b190ca765.png)

- teh check decision page with decision award with cool looking box around it to highlight the awarding state.
![screenshot from 2018-07-18 11-30-09](https://user-images.githubusercontent.com/3073565/42876269-0eaf35ec-8a7e-11e8-84bd-a1b8e6ec7ad3.png)

- Going back to an initial make decision page after a decision has been issued
![screenshot from 2018-07-18 11-30-28](https://user-images.githubusercontent.com/3073565/42876268-0e999d18-8a7e-11e8-8240-dc0c23a16b35.png)