### PR TITLE
RIUI-303 Amend content disposition headers

### DIFF
--- a/api/documents/document.js
+++ b/api/documents/document.js
@@ -30,7 +30,11 @@ module.exports = app => {
 
     route.get('/:document_id/binary', (req, res, next) => {
         const documentId = req.params.document_id;
-        getDocumentBinary(documentId, getOptions(req)).pipe(res);
+        // res.set('Content-disposition', 'attachment; filename=test');
+        getDocumentBinary(documentId, getOptions(req))
+            .on('response', function(response) {
+                response.headers['content-disposition'] = 'attachment; ' + response.headers['content-disposition'];
+            }).pipe(res);
     });
 
     route.get('/:document_id', (req, res, next) => {

--- a/api/documents/document.js
+++ b/api/documents/document.js
@@ -30,7 +30,6 @@ module.exports = app => {
 
     route.get('/:document_id/binary', (req, res, next) => {
         const documentId = req.params.document_id;
-        // res.set('Content-disposition', 'attachment; filename=test');
         getDocumentBinary(documentId, getOptions(req))
             .on('response', function(response) {
                 response.headers['content-disposition'] = 'attachment; ' + response.headers['content-disposition'];


### PR DESCRIPTION
The document download should kick off a download rather than trying to display it in the browser. This header does that. We already get the filename from DM. We should need to set the `attachment` bit.