### PR TITLE
RIUI-763 - Removed back link from the decision confirmation screen

### DIFF
--- a/src/app/routing/pages/decisions/check-decision/check-decision.component.html
+++ b/src/app/routing/pages/decisions/check-decision/check-decision.component.html
@@ -1,3 +1,4 @@
+<app-backlink></app-backlink>
 <div class="jui-width-container" *ngIf="decisionState !== 'decision_issued'; else issuiedDecision">
     <main class="govuk-main-wrapper" role="main">
         <div class="govuk-grid-row">

--- a/src/app/routing/pages/decisions/create-decision/create-decision.component.html
+++ b/src/app/routing/pages/decisions/create-decision/create-decision.component.html
@@ -1,3 +1,4 @@
+<app-backlink></app-backlink>
 <div *ngIf="decisionState !== 'decision_issued'; else issuiedDecision">
 
     <div class="govuk-grid-row govuk-main-wrapper">

--- a/src/app/routing/pages/decisions/decision-confirmation/decision-confirmation.component.html
+++ b/src/app/routing/pages/decisions/decision-confirmation/decision-confirmation.component.html
@@ -4,7 +4,7 @@
             <div class="govuk-grid-column-two-thirds">
                 <div class="govuk-panel govuk-panel--confirmation">
                     <h2 class="govuk-panel__title">Decision confirmed</h2>
-                    <div class="govuk-panel__body">{{case.case_reference}}</div>
+                    <div class="govuk-panel__body">{{case.details.fields[0].value}}</div>
                 </div>
                 <h2 class="govuk-heading-m">What happens next?</h2>
                 <p>We've sent this decision to admin and the case has been removed from your dashboard.</p>

--- a/src/app/routing/pages/decisions/root/root.component.html
+++ b/src/app/routing/pages/decisions/root/root.component.html
@@ -1,7 +1,6 @@
 <div>
     <app-casebar [case]="case"></app-casebar>
     <div class="jui-width-container">
-        <app-backlink></app-backlink>
         <router-outlet></router-outlet>
     </div>
 </div>


### PR DESCRIPTION
This pull request endeavours to remove the presentation of the back link element within the decision confirmation page. It was currently part of the root page component which allowed the element to be shared across all of it's child pages but as it is not desired in the confirmation screen it was removed from the root and placed in each individual child as required.

In addition to the change mentioned above this pull request also contains a small change made to the variable in the templating responsible for the presentation of the case reference number. As the value is not actually passed as part of the raw case data the reference number needs to be taken from the templated case details section. It has been updated to retrieve the correct value but may need some additional work in the future to tidy the code up a little bit.