### PR TITLE
[PREVIEW] - Feature/riui 856 duplicate timeline bug

### DIFF
--- a/api/events/event.js
+++ b/api/events/event.js
@@ -52,7 +52,7 @@ function mergeCohEvents(eventsJson) {
     const questionHistory = eventsJson.online_hearing.questions ? getHistory(eventsJson.online_hearing.questions) : [];
     const answersHistory = eventsJson.online_hearing.answers ? getHistory(eventsJson.online_hearing.answers) : [];
     const decisionHistory = eventsJson.online_hearing.decision ? eventsJson.online_hearing.decision.history : [];
-    return [...history, ...questionHistory, ...answersHistory, ...decisionHistory];
+    return [ ...questionHistory, ...answersHistory, ...decisionHistory];
 }
 
 function sortEvents(events) {

--- a/src/app/domain/services/decision.service.spec.ts
+++ b/src/app/domain/services/decision.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, inject } from '@angular/core/testing';
 
 import { DecisionService } from './decision.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ConfigService } from '../../config.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { DomainModule } from '../domain.module';
@@ -14,7 +14,10 @@ const configMock = {
     }
 };
 
-describe('DecisionService', () => {
+let decisionService: DecisionService;
+let httpMock: HttpTestingController;
+
+fdescribe('DecisionService', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
@@ -32,10 +35,49 @@ describe('DecisionService', () => {
                 }
             ]
         });
+
+
+        decisionService = TestBed.get(DecisionService);
+        httpMock = TestBed.get(HttpTestingController);
+
     });
 
-    it('should be created', inject([DecisionService], (service: DecisionService) => {
-        expect(service)
+
+
+    it('should be created', () => {
+        expect(decisionService)
             .toBeTruthy();
-    }));
+    });
+
+
+    it('should contain case id',() => {
+        const mockCaseId='123';
+        expect(decisionService.generateDecisionUrl(mockCaseId)).toContain(mockCaseId);
+            
+    });
+
+
+    it('should fetch',() => {
+        const mockDecisionData = [{is:1},{id:2}];
+        const mockCaseId='123';
+        const url = decisionService.generateDecisionUrl( mockCaseId);
+
+        decisionService.fetch(mockCaseId).subscribe(data =>{
+           expect(data.length).toBe(2); 
+           expect(data).toEqual(mockDecisionData); 
+        });
+
+        
+        const mockReq = httpMock.expectOne(url);
+        expect(mockReq.request.method).toBe('GET');
+        expect(mockReq.request.responseType).toEqual('json');
+        mockReq.flush(mockDecisionData);
+        httpMock.verify();
+            
+    });
+
+
+
+    
+
 });

--- a/src/app/domain/services/decision.service.spec.ts
+++ b/src/app/domain/services/decision.service.spec.ts
@@ -17,7 +17,11 @@ const configMock = {
 let decisionService: DecisionService;
 let httpMock: HttpTestingController;
 
-fdescribe('DecisionService', () => {
+describe('DecisionService', () => {
+
+    let url;
+    const mockCaseId = "123";
+
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
@@ -39,7 +43,7 @@ fdescribe('DecisionService', () => {
 
         decisionService = TestBed.get(DecisionService);
         httpMock = TestBed.get(HttpTestingController);
-
+        url = decisionService.generateDecisionUrl(mockCaseId);
     });
 
 
@@ -50,34 +54,102 @@ fdescribe('DecisionService', () => {
     });
 
 
-    it('should contain case id',() => {
-        const mockCaseId='123';
+    it('should contain case id', () => {
         expect(decisionService.generateDecisionUrl(mockCaseId)).toContain(mockCaseId);
-            
+
     });
 
 
-    it('should fetch',() => {
-        const mockDecisionData = [{is:1},{id:2}];
-        const mockCaseId='123';
-        const url = decisionService.generateDecisionUrl( mockCaseId);
+    it('should fetch decisions via http GET', () => {
+        const mockDecisionData = [{ id: 1 }, { id: 2 }];
+        //const mockCaseId='123';
+        const url = decisionService.generateDecisionUrl(mockCaseId);
 
-        decisionService.fetch(mockCaseId).subscribe(data =>{
-           expect(data.length).toBe(2); 
-           expect(data).toEqual(mockDecisionData); 
+        decisionService.fetch(mockCaseId).subscribe(data => {
+            expect(data.length).toBe(2);
+            expect(data).toEqual(mockDecisionData);
         });
 
-        
+
         const mockReq = httpMock.expectOne(url);
         expect(mockReq.request.method).toBe('GET');
         expect(mockReq.request.responseType).toEqual('json');
         mockReq.flush(mockDecisionData);
         httpMock.verify();
-            
+
+
     });
 
 
+    it('should submit draft decision via http POST', () => {
 
-    
+        const mockDecisionData = [{ id: 1 }, { id: 2 }];
+        const mockAward = "award data";
+        const mockText = "text data";
+        
+        decisionService.submitDecisionDraft(mockCaseId, mockAward, mockText).subscribe(data => {
+            expect(data.length).toBe(2);
+
+        });
+
+
+        const mockReq = httpMock.expectOne(url);
+        expect(mockReq.request.method).toBe('POST');
+        expect(mockReq.request.responseType).toEqual('json');
+        expect(mockReq.request.body.decision_text).toBe(mockText);
+        expect(mockReq.request.body.decision_award).toBe(mockAward);
+        expect(mockReq.request.url).toBe(url);
+
+        mockReq.flush(mockDecisionData);
+        httpMock.verify();
+
+    })
+
+
+
+
+    it('should update draft decision via http PUT', () => {
+
+        const mockDummyData = [{ id: 1 }, { id: 2 }];
+        const mockAward = "award data";
+        const mockText = "text data";
+
+        decisionService.updateDecisionDraft(mockCaseId, mockAward, mockText).subscribe(data => {
+            console.log('@@@', data);
+             expect(data).toBe(mockDummyData); 
+
+        })
+
+        const mockReq = httpMock.expectOne(url);
+        expect(mockReq.request.method).toBe('PUT');
+        expect(mockReq.request.responseType).toEqual('json');
+
+        mockReq.flush(mockDummyData);
+        httpMock.verify();
+
+
+    })
+
+
+
+    it('should issue decision via http PUT', () => {
+
+        const mockDummyData = [{ id: 1 }, { id: 2 }];
+        const mockAward = "award data";
+        const mockText = "text data";
+
+        decisionService.updateDecisionDraft(mockCaseId, mockAward, mockText).subscribe(data => {
+             expect(data).toBe(mockDummyData); 
+
+        })
+
+        const mockReq = httpMock.expectOne(url);
+        expect(mockReq.request.method).toBe('PUT');
+        expect(mockReq.request.responseType).toEqual('json');
+
+        mockReq.flush(mockDummyData);
+        httpMock.verify();
+
+    })
 
 });

--- a/src/app/domain/services/decision.service.spec.ts
+++ b/src/app/domain/services/decision.service.spec.ts
@@ -61,20 +61,20 @@ describe('DecisionService', () => {
 
 
     it('should fetch decisions via http GET', () => {
-        const mockDecisionData = [{ id: 1 }, { id: 2 }];
+        const mockDummyData = [{ id: 1 }, { id: 2 }];
         //const mockCaseId='123';
         const url = decisionService.generateDecisionUrl(mockCaseId);
 
         decisionService.fetch(mockCaseId).subscribe(data => {
             expect(data.length).toBe(2);
-            expect(data).toEqual(mockDecisionData);
+            expect(data).toEqual(mockDummyData);
         });
 
 
         const mockReq = httpMock.expectOne(url);
         expect(mockReq.request.method).toBe('GET');
         expect(mockReq.request.responseType).toEqual('json');
-        mockReq.flush(mockDecisionData);
+        mockReq.flush(mockDummyData);
         httpMock.verify();
 
 
@@ -83,7 +83,7 @@ describe('DecisionService', () => {
 
     it('should submit draft decision via http POST', () => {
 
-        const mockDecisionData = [{ id: 1 }, { id: 2 }];
+        const mockDummyData = [{ id: 1 }, { id: 2 }];
         const mockAward = "award data";
         const mockText = "text data";
         
@@ -100,7 +100,7 @@ describe('DecisionService', () => {
         expect(mockReq.request.body.decision_award).toBe(mockAward);
         expect(mockReq.request.url).toBe(url);
 
-        mockReq.flush(mockDecisionData);
+        mockReq.flush(mockDummyData);
         httpMock.verify();
 
     })
@@ -115,7 +115,6 @@ describe('DecisionService', () => {
         const mockText = "text data";
 
         decisionService.updateDecisionDraft(mockCaseId, mockAward, mockText).subscribe(data => {
-            console.log('@@@', data);
              expect(data).toBe(mockDummyData); 
 
         })


### PR DESCRIPTION
removed history spread operator to prevent merging of duplicate  'decision issued' in COH timeline events